### PR TITLE
Add animated paddle rally canvas

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,46 +1,65 @@
-/* Basic styling for the body to center content (optional) */
+:root {
+    --bg-color: #040714;
+    --bg-gradient: linear-gradient(135deg, #040714 0%, #0b1221 50%, #1b2440 100%);
+    --text-color: #e2e8f0;
+    --muted-text: #94a3b8;
+    --accent: #42ffcb;
+    --accent-soft: rgba(66, 255, 203, 0.35);
+    --highlight: #fbbf24;
+    --shadow: rgba(4, 7, 20, 0.65);
+    --card-bg: rgba(15, 23, 42, 0.65);
+}
+
+* {
+    box-sizing: border-box;
+}
+
 body {
-    font-family: Arial, sans-serif; /* Choose a font you like */
-    display: flex;
-    flex-direction: column; /* Stack header and other content vertically */
-    align-items: center;    /* Center content horizontally */
-    /* justify-content: center; /* Uncomment this if you want vertical centering of all body content */
-    /* min-height: 100vh; /* Use this with justify-content: center for full vertical centering */
+    font-family: 'Manrope', 'Roboto Mono', monospace;
     margin: 0;
-    padding: 20px; /* Add some padding around the content */
-    text-align: center; /* Center text within elements */
-    background-color: #f4f4f4; /* A light background color */
-    color: #333; /* Default text color */
+    min-height: 100vh;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 48px 20px 32px;
+    background: var(--bg-gradient);
+    color: var(--text-color);
+    text-align: center;
 }
 
 .main-header {
-    margin-bottom: 30px; /* Space below the header */
+    width: 100%;
+    max-width: 900px;
+    margin-bottom: 36px;
 }
 
 .main-header h1 {
-    font-size: 3em;  /* Adjust size as needed */
-    margin-bottom: 10px; /* Space below the main heading */
-    color: #2c3e50; /* A darker color for the main heading */
+    font-size: clamp(2.8rem, 4vw, 4.2rem);
+    letter-spacing: 0.08em;
+    margin: 0 0 10px;
+    text-transform: uppercase;
 }
 
 .subheading {
-    font-size: 1.5em; /* Adjust size as needed */
-    color: #7f8c8d;   /* A slightly lighter color for the subheading */
-    height: 1.8em; /* Set a fixed height to prevent layout jumps, adjust based on font size */
-    display: inline-block; /* Allows cursor to be next to text */
+    font-size: clamp(1.2rem, 2.5vw, 1.75rem);
+    color: var(--muted-text);
+    min-height: 1.8em;
+    display: inline-block;
 }
 
-/* Blinking cursor effect for the animated subheading */
 .subheading::after {
     content: '|';
     display: inline-block;
-    animation: blink 0.7s infinite;
-    margin-left: 5px; /* Space between text and cursor */
-    color: #7f8c8d; /* Cursor color */
+    margin-left: 8px;
+    animation: blink 0.7s steps(2, start) infinite;
+    color: var(--accent);
 }
 
 @keyframes blink {
-    0%, 100% {
+    0%,
+    100% {
         opacity: 1;
     }
     50% {
@@ -48,3 +67,57 @@ body {
     }
 }
 
+main {
+    width: 100%;
+    flex: 1;
+    display: flex;
+    justify-content: center;
+}
+
+.content-section {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+.game-container {
+    width: 100%;
+    max-width: 900px;
+    padding: 28px;
+    border-radius: 28px;
+    background: var(--card-bg);
+    border: 1px solid var(--accent-soft);
+    box-shadow: 0 24px 48px var(--shadow), 0 0 40px rgba(66, 255, 203, 0.12);
+    backdrop-filter: blur(8px);
+}
+
+#pongCanvas {
+    width: 100%;
+    height: auto;
+    display: block;
+    border-radius: 20px;
+    border: 2px solid var(--accent-soft);
+    background: radial-gradient(circle at 50% 50%, rgba(15, 25, 40, 0.9) 0%, rgba(10, 14, 30, 0.95) 60%, rgba(4, 7, 20, 0.98) 100%);
+    box-shadow: 0 20px 40px rgba(4, 7, 20, 0.6), 0 0 30px rgba(66, 255, 203, 0.25);
+}
+
+footer {
+    margin-top: 32px;
+    color: var(--muted-text);
+    font-size: 0.9rem;
+}
+
+@media (max-width: 640px) {
+    body {
+        padding: 32px 16px;
+    }
+
+    .game-container {
+        padding: 20px;
+        border-radius: 22px;
+    }
+
+    #pongCanvas {
+        border-radius: 16px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -4,41 +4,27 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chris Skelton</title>
-    <link rel="stylesheet" href="css/style.css"> 
+    <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&family=Manrope:wght@400;700;800&display=swap" rel="stylesheet">
 </head>
 <body>
-
-    <header class="main-header"></header>
-    <h1>chrsskltn</h1>
-    <p id="animated-subheading" class="subheading"></p>
+    <header class="main-header">
+        <h1>chrsskltn</h1>
+        <p id="animated-subheading" class="subheading" aria-live="polite"></p>
     </header>
 
     <main>
-     <section id="about" class="content-section">
-            
-           
-        </section>
-
-       
-<!--
-        <section id="contact" class="content-section">
-            <h2>Get In Touch</h2>
-            <p></p>
-            <div class="contact-links">
-                <a href="https://github.com/chrsskltn" class="button contact-button" target="_blank" rel="noopener noreferrer">GitHub</a>
-                <a href="https:/www.linkedin.com/in/chris-skelton-89a02815b/" class="button contact-button" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-                </div>
+        <section id="about" class="content-section">
+            <div class="game-container">
+                <canvas id="pongCanvas" width="800" height="400" aria-label="Animated paddle game"></canvas>
+            </div>
         </section>
     </main>
--->
+
     <footer>
         <p>&copy; <span id="current-year"></span> chrsskltn. All rights reserved.</p>
     </footer>
 
-
-
-
-    <script src="js/script.js"></script> 
+    <script src="js/script.js"></script>
 </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,31 +1,225 @@
-document.addEventListener('DOMContentLoaded', function() { // Wait for the HTML to load
+document.addEventListener('DOMContentLoaded', () => {
+    setupHeadingAnimation();
+    setupPaddleGame();
+    updateCurrentYear();
+});
 
+function setupHeadingAnimation() {
     const animatedSubheading = document.getElementById('animated-subheading');
-    const textToAnimate = "search and you shall find";
-    let charIndex = 0;
-    let typingSpeed = 150; // Milliseconds per character
-    let delayBeforeRestart = 2000; // Milliseconds to wait after text is typed
+    if (!animatedSubheading) {
+        return;
+    }
 
-    function typeText() {
+    const textToAnimate = 'search and you shall find';
+    let charIndex = 0;
+    const typingSpeed = 150;
+    const delayBeforeRestart = 2000;
+
+    const typeText = () => {
+        if (!animatedSubheading) {
+            return;
+        }
+
         if (charIndex < textToAnimate.length) {
             animatedSubheading.textContent += textToAnimate.charAt(charIndex);
-            charIndex++;
+            charIndex += 1;
             setTimeout(typeText, typingSpeed);
         } else {
-            // Text fully typed
             setTimeout(eraseAndRestart, delayBeforeRestart);
         }
-    }
+    };
 
-    function eraseAndRestart() {
-        animatedSubheading.textContent = ''; // Clear the text
-        charIndex = 0; // Reset character index
-        // Optional: slight delay before typing starts again
-        // setTimeout(typeText, 500);
-        typeText(); // Start typing again immediately
-    }
+    const eraseAndRestart = () => {
+        animatedSubheading.textContent = '';
+        charIndex = 0;
+        typeText();
+    };
 
-    // Initial call to start the animation
     typeText();
+}
 
-});
+function setupPaddleGame() {
+    const canvas = document.getElementById('pongCanvas');
+    if (!canvas || !canvas.getContext) {
+        return;
+    }
+
+    const ctx = canvas.getContext('2d');
+
+    const paddleConfig = {
+        width: 16,
+        height: 110,
+        margin: 42,
+        speed: 3.4
+    };
+
+    const createPaddle = (xPosition) => ({
+        x: xPosition,
+        y: (canvas.height - paddleConfig.height) / 2,
+        width: paddleConfig.width,
+        height: paddleConfig.height,
+        speed: paddleConfig.speed
+    });
+
+    const leftPaddle = createPaddle(paddleConfig.margin);
+    const rightPaddle = createPaddle(canvas.width - paddleConfig.margin - paddleConfig.width);
+
+    const ball = {
+        x: canvas.width / 2,
+        y: canvas.height / 2,
+        radius: 9,
+        speed: 4.2,
+        velocityX: 4.2,
+        velocityY: 2.4,
+        maxSpeed: 8
+    };
+
+    const resetBall = (direction = 1) => {
+        ball.x = canvas.width / 2;
+        ball.y = canvas.height / 2;
+        ball.speed = 4.2;
+
+        const angle = (Math.random() * Math.PI) / 3 - Math.PI / 6; // -30deg to 30deg
+        ball.velocityX = direction * ball.speed * Math.cos(angle);
+        ball.velocityY = ball.speed * Math.sin(angle);
+    };
+
+    resetBall(Math.random() > 0.5 ? 1 : -1);
+
+    const drawBackground = () => {
+        const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+        gradient.addColorStop(0, 'rgba(15, 23, 42, 0.95)');
+        gradient.addColorStop(0.5, 'rgba(12, 20, 36, 0.95)');
+        gradient.addColorStop(1, 'rgba(8, 12, 25, 0.95)');
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        ctx.fillStyle = 'rgba(66, 255, 203, 0.3)';
+        ctx.shadowBlur = 0;
+        const segmentHeight = 18;
+        const gap = 12;
+        for (let y = 0; y < canvas.height; y += segmentHeight + gap) {
+            ctx.fillRect(canvas.width / 2 - 2, y, 4, segmentHeight);
+        }
+    };
+
+    const drawPaddle = (paddle) => {
+        ctx.fillStyle = '#42ffcb';
+        ctx.shadowBlur = 18;
+        ctx.shadowColor = 'rgba(66, 255, 203, 0.55)';
+        ctx.fillRect(paddle.x, paddle.y, paddle.width, paddle.height);
+        ctx.shadowBlur = 0;
+    };
+
+    const drawBall = () => {
+        ctx.beginPath();
+        ctx.fillStyle = '#fbbf24';
+        ctx.shadowBlur = 22;
+        ctx.shadowColor = 'rgba(251, 191, 36, 0.6)';
+        ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.closePath();
+        ctx.shadowBlur = 0;
+    };
+
+    const clampPaddle = (paddle) => {
+        if (paddle.y < 0) {
+            paddle.y = 0;
+        } else if (paddle.y + paddle.height > canvas.height) {
+            paddle.y = canvas.height - paddle.height;
+        }
+    };
+
+    const updatePaddlePosition = (paddle, isBallMovingTowards) => {
+        const targetY = isBallMovingTowards
+            ? ball.y - paddle.height / 2
+            : (canvas.height - paddle.height) / 2;
+
+        const adjustmentSpeed = paddle.speed * (isBallMovingTowards ? 1 : 0.35);
+        if (Math.abs(targetY - paddle.y) > adjustmentSpeed) {
+            paddle.y += Math.sign(targetY - paddle.y) * adjustmentSpeed;
+        } else {
+            paddle.y = targetY;
+        }
+
+        clampPaddle(paddle);
+    };
+
+    const handlePaddleCollision = (paddle, direction) => {
+        const paddleCenter = paddle.y + paddle.height / 2;
+        const distanceFromCenter = ball.y - paddleCenter;
+        const normalized = distanceFromCenter / (paddle.height / 2);
+        const clampedNormalized = Math.max(-1, Math.min(1, normalized));
+
+        const maxBounceAngle = (Math.PI / 4);
+        const bounceAngle = clampedNormalized * maxBounceAngle;
+
+        ball.speed = Math.min(ball.speed + 0.25, ball.maxSpeed);
+        ball.velocityX = direction * ball.speed * Math.cos(bounceAngle);
+        ball.velocityY = ball.speed * Math.sin(bounceAngle);
+        ball.x = direction < 0
+            ? paddle.x - ball.radius
+            : paddle.x + paddle.width + ball.radius;
+    };
+
+    const updateBall = () => {
+        ball.x += ball.velocityX;
+        ball.y += ball.velocityY;
+
+        if (ball.y - ball.radius <= 0 || ball.y + ball.radius >= canvas.height) {
+            ball.velocityY *= -1;
+            ball.y = Math.max(ball.radius, Math.min(canvas.height - ball.radius, ball.y));
+        }
+
+        if (
+            ball.velocityX < 0 &&
+            ball.x - ball.radius <= leftPaddle.x + leftPaddle.width &&
+            ball.y >= leftPaddle.y &&
+            ball.y <= leftPaddle.y + leftPaddle.height
+        ) {
+            handlePaddleCollision(leftPaddle, 1);
+        }
+
+        if (
+            ball.velocityX > 0 &&
+            ball.x + ball.radius >= rightPaddle.x &&
+            ball.y >= rightPaddle.y &&
+            ball.y <= rightPaddle.y + rightPaddle.height
+        ) {
+            handlePaddleCollision(rightPaddle, -1);
+        }
+
+        if (ball.x + ball.radius < 0) {
+            resetBall(1);
+        } else if (ball.x - ball.radius > canvas.width) {
+            resetBall(-1);
+        }
+    };
+
+    const draw = () => {
+        drawBackground();
+        drawPaddle(leftPaddle);
+        drawPaddle(rightPaddle);
+        drawBall();
+    };
+
+    const update = () => {
+        updatePaddlePosition(leftPaddle, ball.velocityX < 0);
+        updatePaddlePosition(rightPaddle, ball.velocityX > 0);
+        updateBall();
+        draw();
+        requestAnimationFrame(update);
+    };
+
+    update();
+}
+
+function updateCurrentYear() {
+    const currentYearSpan = document.getElementById('current-year');
+    if (!currentYearSpan) {
+        return;
+    }
+
+    const currentYear = new Date().getFullYear();
+    currentYearSpan.textContent = String(currentYear);
+}


### PR DESCRIPTION
## Summary
- add a hero canvas that animates two paddles rallying a ball back and forth
- refresh the site styles with neon-inspired theming to frame the animation
- refactor the script to initialize the typing effect, paddle rally, and auto-update the footer year

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0f9c28e50832b89e8f4150ec38bd2